### PR TITLE
Add Blender scripts for basic asset generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/blender_scripts/bench.py
+++ b/blender_scripts/bench.py
@@ -1,0 +1,32 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_bench():
+    """Build a simple park bench with seat, backrest, and four legs."""
+    clear_scene()
+
+    # Seat
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 0.5))
+    seat = bpy.context.active_object
+    seat.scale = (1.5, 0.3, 0.1)
+    seat.name = "Seat"
+
+    # Backrest
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, -0.4, 1.0))
+    back = bpy.context.active_object
+    back.scale = (1.5, 0.1, 0.5)
+    back.name = "Backrest"
+
+    # Legs
+    for x in (-1.4, 1.4):
+        for y in (-0.25, 0.25):
+            bpy.ops.mesh.primitive_cube_add(size=1, location=(x, y, 0.25))
+            leg = bpy.context.active_object
+            leg.scale = (0.1, 0.1, 0.5)
+            leg.name = f"Leg_{x}_{y}"
+
+if __name__ == "__main__":
+    create_bench()

--- a/blender_scripts/chair.py
+++ b/blender_scripts/chair.py
@@ -1,0 +1,32 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_chair():
+    """Build a simple chair from cubes."""
+    clear_scene()
+
+    # Seat
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 0.5))
+    seat = bpy.context.active_object
+    seat.scale = (1, 1, 0.1)
+    seat.name = "Seat"
+
+    # Backrest
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, -0.9, 1.3))
+    back = bpy.context.active_object
+    back.scale = (1, 0.1, 0.8)
+    back.name = "Backrest"
+
+    # Legs
+    for x in (-0.9, 0.9):
+        for y in (-0.9, 0.9):
+            bpy.ops.mesh.primitive_cube_add(size=1, location=(x, y, 0.25))
+            leg = bpy.context.active_object
+            leg.scale = (0.1, 0.1, 0.5)
+            leg.name = f"Leg_{x}_{y}"
+
+if __name__ == "__main__":
+    create_chair()

--- a/blender_scripts/fire_hydrant.py
+++ b/blender_scripts/fire_hydrant.py
@@ -1,0 +1,39 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_fire_hydrant():
+    """Create a basic fire hydrant with body, cap, and nozzles."""
+    clear_scene()
+
+    # Base
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.35, depth=0.1, location=(0, 0, 0.05))
+    base = bpy.context.active_object
+    base.name = "Base"
+
+    # Body
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.3, depth=1, location=(0, 0, 0.6))
+    body = bpy.context.active_object
+    body.name = "Body"
+
+    # Cap
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.35, depth=0.2, location=(0, 0, 1.15))
+    cap = bpy.context.active_object
+    cap.name = "Cap"
+
+    # Top nut
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=0.1, location=(0, 0, 1.3))
+    top = bpy.context.active_object
+    top.name = "TopNut"
+
+    # Side nozzles
+    for x in (-0.5, 0.5):
+        bpy.ops.mesh.primitive_cylinder_add(radius=0.1, depth=0.4, location=(x, 0, 0.8))
+        nozzle = bpy.context.active_object
+        nozzle.rotation_euler[1] = 1.5708
+        nozzle.name = f"Nozzle_{x}"
+
+if __name__ == "__main__":
+    create_fire_hydrant()

--- a/blender_scripts/mailbox.py
+++ b/blender_scripts/mailbox.py
@@ -1,0 +1,30 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_mailbox():
+    """Create a simple mailbox on a post."""
+    clear_scene()
+
+    # Post
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.1, depth=2, location=(0, 0, 1))
+    post = bpy.context.active_object
+    post.name = "Post"
+
+    # Box body
+    bpy.ops.mesh.primitive_cube_add(size=1, location=(0, 0.4, 1.8))
+    body = bpy.context.active_object
+    body.scale = (0.5, 0.4, 0.3)
+    body.name = "Box"
+
+    # Rounded top
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.5, depth=0.8, location=(0, 0.4, 2.1))
+    top = bpy.context.active_object
+    top.rotation_euler[0] = 1.5708
+    top.scale = (1, 1, 0.6)
+    top.name = "Top"
+
+if __name__ == "__main__":
+    create_mailbox()

--- a/blender_scripts/simple_house.py
+++ b/blender_scripts/simple_house.py
@@ -1,0 +1,23 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_house():
+    """Build a simple house with a cube base and pyramid roof."""
+    clear_scene()
+
+    # Base of the house
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 1))
+    base = bpy.context.active_object
+    base.scale = (2, 2, 1)
+    base.name = "HouseBase"
+
+    # Roof
+    bpy.ops.mesh.primitive_cone_add(vertices=4, radius1=2.2, depth=1.5, location=(0, 0, 2.75))
+    roof = bpy.context.active_object
+    roof.name = "Roof"
+
+if __name__ == "__main__":
+    create_house()

--- a/blender_scripts/street_lamp.py
+++ b/blender_scripts/street_lamp.py
@@ -1,0 +1,27 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_street_lamp():
+    """Build a basic street lamp with a pole, arm, and lamp head."""
+    clear_scene()
+
+    # Vertical pole
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.05, depth=3, location=(0, 0, 1.5))
+    pole = bpy.context.active_object
+    pole.name = "Pole"
+
+    # Horizontal arm
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.03, depth=0.8, location=(0.4, 0, 3), rotation=(0, 0, 1.5708))
+    arm = bpy.context.active_object
+    arm.name = "Arm"
+
+    # Lamp head
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=0.12, location=(0.8, 0, 3))
+    head = bpy.context.active_object
+    head.name = "LampHead"
+
+if __name__ == "__main__":
+    create_street_lamp()

--- a/blender_scripts/table.py
+++ b/blender_scripts/table.py
@@ -1,0 +1,25 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_table():
+    """Build a simple table with a rectangular top and four cylindrical legs."""
+    clear_scene()
+
+    # Table top
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 1))
+    top = bpy.context.active_object
+    top.scale = (1.5, 1, 0.1)
+    top.name = "TableTop"
+
+    # Legs
+    for x in (-1.3, 1.3):
+        for y in (-0.8, 0.8):
+            bpy.ops.mesh.primitive_cylinder_add(radius=0.05, depth=0.9, location=(x, y, 0.45))
+            leg = bpy.context.active_object
+            leg.name = f"Leg_{x}_{y}"
+
+if __name__ == "__main__":
+    create_table()

--- a/blender_scripts/trash_can.py
+++ b/blender_scripts/trash_can.py
@@ -1,0 +1,29 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_trash_can():
+    """Create a basic cylindrical trash can with lid and handles."""
+    clear_scene()
+
+    # Body
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.5, depth=1, location=(0, 0, 0.5))
+    body = bpy.context.active_object
+    body.name = "CanBody"
+
+    # Lid
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.55, depth=0.1, location=(0, 0, 1.05))
+    lid = bpy.context.active_object
+    lid.name = "Lid"
+
+    # Handles
+    for x in (-0.6, 0.6):
+        bpy.ops.mesh.primitive_cube_add(size=0.2, location=(x, 0, 0.9))
+        handle = bpy.context.active_object
+        handle.scale = (0.1, 0.05, 0.05)
+        handle.name = f"Handle_{x}"
+
+if __name__ == "__main__":
+    create_trash_can()

--- a/blender_scripts/tree.py
+++ b/blender_scripts/tree.py
@@ -1,0 +1,22 @@
+import bpy
+
+def clear_scene():
+    bpy.ops.object.select_all(action='SELECT')
+    bpy.ops.object.delete(use_global=False)
+
+def create_tree():
+    """Build a stylized tree using a cylinder trunk and cone foliage."""
+    clear_scene()
+
+    # Trunk
+    bpy.ops.mesh.primitive_cylinder_add(radius=0.1, depth=2, location=(0, 0, 1))
+    trunk = bpy.context.active_object
+    trunk.name = "Trunk"
+
+    # Foliage
+    bpy.ops.mesh.primitive_cone_add(radius1=1, depth=2, location=(0, 0, 2.5))
+    foliage = bpy.context.active_object
+    foliage.name = "Foliage"
+
+if __name__ == "__main__":
+    create_tree()


### PR DESCRIPTION
## Summary
- add Blender Python scripts to generate basic assets: chair, table, street lamp, tree, simple house, bench, trash can, mailbox, and fire hydrant
- include .gitignore to skip Python cache files

## Testing
- `python -m py_compile blender_scripts/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ffadea008323a6d662aad1cc841d